### PR TITLE
Support Perl 5.42

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ jobs:
       matrix:
         perl:
           [
+            "5.42",
+            "5.40",
+            "5.38",
             "5.36",
             "5.34",
             "5.32",
@@ -24,7 +27,7 @@ jobs:
           ]
     name: Perl ${{ matrix.perl }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup perl
         uses: shogo82148/actions-setup-perl@v1
         with:


### PR DESCRIPTION
## Summary
- Add Perl 5.38, 5.40, 5.42 to the GitHub Actions CI test matrix
- Update actions/checkout from v3 to v4

## Test plan
- [x] Verify GitHub Actions workflow runs successfully on all Perl versions

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)